### PR TITLE
refactor: BaseEntity 생성 및 기존 엔티티 수정

### DIFF
--- a/src/main/java/com/sk/domain/auth/domain/Member.java
+++ b/src/main/java/com/sk/domain/auth/domain/Member.java
@@ -1,13 +1,13 @@
 package com.sk.domain.auth.domain;
 
 import com.sk.domain.board.domain.Board;
+import com.sk.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -15,9 +15,8 @@ import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sk/domain/board/domain/Attachment.java
+++ b/src/main/java/com/sk/domain/board/domain/Attachment.java
@@ -1,20 +1,19 @@
 package com.sk.domain.board.domain;
 
+import com.sk.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Attachment {
+public class Attachment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -1,13 +1,13 @@
 package com.sk.domain.board.domain;
 
 import com.sk.domain.auth.domain.Member;
+import com.sk.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -15,9 +15,8 @@ import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Board {
+public class Board extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sk/global/entity/BaseEntity.java
+++ b/src/main/java/com/sk/global/entity/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.sk.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false; // 삭제 여부
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정일시
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- BaseEntity 생성 및 공통 필드 관리
- 기존 엔티티에 BaseEntity 상속 적용 및 중복 필드 제거

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?
- BaseEntity 생성
  - is_deleted, created_at, updated_at 필드 추가
- 기존 엔티티 수정
  - Member, Board, Attachment 엔티티에서 BaseEntity 상속
  - 기존 중복 필드(created_at, updated_at, is_deleted) 제거

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
- api 호출하여 정상 동작 여부 확인

---
