### PR TITLE
refactor: AuthRepository 변경 및 불필요한 API 삭제

### DIFF
--- a/src/main/java/com/sk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/sk/domain/auth/api/AuthController.java
@@ -54,17 +54,6 @@ public class AuthController {
                 ));
     }
 
-    // 로그인 인증 테스트 API
-    @GetMapping("/data")
-    public ResponseEntity<ApiSuccessResponse<String>> getData() {
-        return ResponseEntity.ok()
-                .body(ApiSuccessResponse.of(
-                        HttpStatus.OK,
-                        "/api/auth/data",
-                        "인증 성공"
-                ));
-    }
-
     // 로그아웃
     @PostMapping("/sign-out")
     public ResponseEntity<ApiSuccessResponse<Void>> signOut(HttpServletRequest servRequest) {

--- a/src/main/java/com/sk/domain/auth/application/AuthService.java
+++ b/src/main/java/com/sk/domain/auth/application/AuthService.java
@@ -4,7 +4,7 @@ import com.sk.domain.auth.api.dto.request.SignInRequest;
 import com.sk.domain.auth.api.dto.request.SignUpRequest;
 import com.sk.domain.auth.domain.Member;
 import com.sk.domain.auth.exception.*;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final AuthRepository authRepository;
+    private final MemberRepository authRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/sk/domain/auth/repository/MemberRepository.java
+++ b/src/main/java/com/sk/domain/auth/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface AuthRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);

--- a/src/main/java/com/sk/domain/board/application/BoardService.java
+++ b/src/main/java/com/sk/domain/board/application/BoardService.java
@@ -3,7 +3,7 @@ package com.sk.domain.board.application;
 import com.sk.domain.auth.domain.Member;
 import com.sk.domain.auth.exception.AccessDeniedException;
 import com.sk.domain.auth.exception.UserNotFoundException;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.domain.board.api.dto.request.BoardCreateRequest;
 import com.sk.domain.board.api.dto.request.BoardUpdateRequest;
 import com.sk.domain.board.api.dto.response.AttachmentResponse;
@@ -30,7 +30,7 @@ import java.util.List;
 @Service
 public class BoardService {
 
-    private final AuthRepository authRepository;
+    private final MemberRepository authRepository;
     private final BoardRepository boardRepository;
     private final AttachmentRepository attachmentRepository;
 

--- a/src/main/java/com/sk/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sk/global/security/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,7 @@ package com.sk.global.security.filter;
 
 import com.sk.domain.auth.domain.Member;
 import com.sk.domain.auth.exception.UserNotFoundException;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.global.security.CustomUserDetails;
 import com.sk.global.security.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
@@ -23,7 +23,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final AuthRepository authRepository;
+    private final MemberRepository authRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/test/java/com/sk/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/sk/domain/auth/api/AuthControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sk.domain.auth.api.dto.request.SignInRequest;
 import com.sk.domain.auth.api.dto.request.SignUpRequest;
 import com.sk.domain.auth.domain.Member;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class AuthControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private AuthRepository authRepository;
+    private MemberRepository authRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;

--- a/src/test/java/com/sk/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/sk/domain/auth/application/AuthServiceTest.java
@@ -7,7 +7,7 @@ import com.sk.domain.auth.exception.DuplicateEmailException;
 import com.sk.domain.auth.exception.InvalidEmailOrPasswordException;
 import com.sk.domain.auth.exception.InvalidTokenException;
 import com.sk.domain.auth.exception.PasswordMismatchException;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +25,7 @@ class AuthServiceTest {
     private AuthService authService;
 
     @Autowired
-    private AuthRepository authRepository;
+    private MemberRepository authRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;

--- a/src/test/java/com/sk/domain/board/api/BoardControllerTest.java
+++ b/src/test/java/com/sk/domain/board/api/BoardControllerTest.java
@@ -3,7 +3,7 @@ package com.sk.domain.board.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sk.domain.auth.api.dto.request.SignInRequest;
 import com.sk.domain.auth.domain.Member;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.domain.board.domain.Attachment;
 import com.sk.domain.board.repository.AttachmentRepository;
 import com.sk.domain.board.repository.BoardRepository;
@@ -38,7 +38,7 @@ class BoardControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private AuthRepository authRepository;
+    private MemberRepository authRepository;
 
     @Autowired
     private BoardRepository boardRepository;

--- a/src/test/java/com/sk/domain/board/application/BoardServiceTest.java
+++ b/src/test/java/com/sk/domain/board/application/BoardServiceTest.java
@@ -1,7 +1,7 @@
 package com.sk.domain.board.application;
 
 import com.sk.domain.auth.domain.Member;
-import com.sk.domain.auth.repository.AuthRepository;
+import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.domain.board.api.dto.request.BoardCreateRequest;
 import com.sk.domain.board.domain.Attachment;
 import com.sk.domain.board.domain.Board;
@@ -26,7 +26,7 @@ class BoardServiceTest {
     private BoardService boardService;
 
     @Autowired
-    private AuthRepository authRepository;
+    private MemberRepository authRepository;
 
     @Autowired
     private BoardRepository boardRepository;


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- AuthRepository의 이름을 MemberRepository로 변경하여 도메인 명확성을 개선
- 불필요한 로그인 인증 테스트 API 삭제

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?
- AuthRepository를 MemberRepository로 변경
  - Member 도메인을 다루는 Repository로 더 명확한 의도 전달
- 불필요한 로그인 인증 테스트 API 삭제

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
- 

---
