### PR TITLE
refactor: 각 엔티티 수정 및 게시글 삭제 시 첨부파일 삭제 로직 수정

### DIFF
--- a/src/main/java/com/sk/domain/auth/domain/Member.java
+++ b/src/main/java/com/sk/domain/auth/domain/Member.java
@@ -5,10 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -31,20 +27,14 @@ public class Member extends BaseEntity {
     @Column(name = "access_token")
     private String accessToken;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    public Member(String email, String name, String password) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+    }
 
     public static Member of(String email, String name, String password) {
-        Member user = new Member();
-        user.email = email;
-        user.name = name;
-        user.password = password;
-        return user;
+        return new Member(email, name, password);
     }
 
     public void updateAccessToken(String accessToken) {

--- a/src/main/java/com/sk/domain/auth/domain/Member.java
+++ b/src/main/java/com/sk/domain/auth/domain/Member.java
@@ -1,6 +1,5 @@
 package com.sk.domain.auth.domain;
 
-import com.sk.domain.board.domain.Board;
 import com.sk.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,8 +9,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -41,9 +38,6 @@ public class Member extends BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    private List<Board> boards = new ArrayList<>(); // 게시글 목록
 
     public static Member of(String email, String name, String password) {
         Member user = new Member();

--- a/src/main/java/com/sk/domain/board/application/BoardService.java
+++ b/src/main/java/com/sk/domain/board/application/BoardService.java
@@ -117,6 +117,7 @@ public class BoardService {
             throw new AccessDeniedException();
         }
 
+        board.deleteAttachments();
         board.delete();
     }
 

--- a/src/main/java/com/sk/domain/board/domain/Attachment.java
+++ b/src/main/java/com/sk/domain/board/domain/Attachment.java
@@ -5,10 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -30,26 +26,11 @@ public class Attachment extends BaseEntity {
     @Column(name = "file_data", nullable = false, columnDefinition = "LONGBLOB")
     private byte[] fileData; // 파일 데이터
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false; // 삭제 여부
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     public static Attachment of(Board board, String fileName, byte[] fileData) {
         Attachment attachment = new Attachment();
         attachment.board = board;
         attachment.fileName = fileName;
         attachment.fileData = fileData;
         return attachment;
-    }
-
-    public void delete() {
-        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/sk/domain/board/domain/Attachment.java
+++ b/src/main/java/com/sk/domain/board/domain/Attachment.java
@@ -16,7 +16,11 @@ public class Attachment extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_id", nullable = false)
+    @JoinColumn(
+            name = "board_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_ATTACHMENT_BOARD")
+    )
     private Board board; // 게시글
 
     @Column(name = "file_name", nullable = false)

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -66,4 +66,9 @@ public class Board extends BaseEntity {
     public void increaseViews() {
         this.views++;
     }
+
+    public void deleteAttachments() {
+        this.attachments.forEach(Attachment::delete);
+    }
+
 }

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -20,7 +20,11 @@ public class Board extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(
+            name = "member_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "FK_BOARD_MEMBER")
+    )
     private Member member; // 작성자
 
     @Column(nullable = false, length = 100)

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -6,10 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,17 +35,6 @@ public class Board extends BaseEntity {
     @Column(name = "has_attachments", nullable = false)
     private boolean hasAttachments = false; // 첨부파일 여부
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false; // 삭제 여부
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private List<Attachment> attachments = new ArrayList<>();
 
@@ -65,10 +51,6 @@ public class Board extends BaseEntity {
         this.title = title;
         this.content = content;
         this.hasAttachments = hasAttachments;
-    }
-
-    public void delete() {
-        this.isDeleted = true;
     }
 
     public void increaseViews() {

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -38,13 +38,15 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private List<Attachment> attachments = new ArrayList<>();
 
+    public Board(Member member, String title, String content, boolean hasAttachments) {
+        this.member = member;
+        this.title = title;
+        this.content = content;
+        this.hasAttachments = hasAttachments;
+    }
+
     public static Board of(Member member, String title, String content, boolean hasAttachments) {
-        Board board = new Board();
-        board.member = member;
-        board.title = title;
-        board.content = content;
-        board.hasAttachments = hasAttachments;
-        return board;
+        return new Board(member, title, content, hasAttachments);
     }
 
     public void update(String title, String content, boolean hasAttachments) {

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -39,7 +39,11 @@ public class Board extends BaseEntity {
     @Column(name = "has_attachments", nullable = false)
     private boolean hasAttachments = false; // 첨부파일 여부
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    @OneToMany(
+            mappedBy = "board",
+            cascade = CascadeType.REMOVE,
+            fetch = FetchType.LAZY
+    )
     private List<Attachment> attachments = new ArrayList<>();
 
     public Board(Member member, String title, String content, boolean hasAttachments) {


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- Member 엔티티에서 불필요한 @OneToMany 연관관계 제거
- 정적 팩토리 메서드에서 생성자 호출 방식으로 변경하여 코드 가독성 및 일관성 개선
- Board 엔티티의 첨부파일 연관 관계 수정 및 외래 키 제약 조건 이름 설정
- BaseEntity에서 중복되는 필드 제거
- 게시글 삭제 시 첨부파일 삭제 처리

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?
- Member 엔티티의 불필요한 양방향 연관관계 제거
- Board 엔티티와 Attachment 엔티티의 정적 팩토리 메서드 리팩토링
- Board 엔티티의 첨부파일 관계 영속성 전이를 CascadeType.REMOVE로 수정
- 외래 키 제약 조건 이름을 명시적으로 설정하여 랜덤한 이름으로 등록 방지
- 게시글 삭제 시 첨부파일 is_deleted 플래그를 true로 설정

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
- 게시글 삭제 시 게시글과 첨부파일 is_deleted 플래그가 true 변경 되는 것 확인

---
