### PR TITLE
refactor: 게시글 로직 개선

### DIFF
--- a/src/main/java/com/sk/domain/board/api/BoardController.java
+++ b/src/main/java/com/sk/domain/board/api/BoardController.java
@@ -1,9 +1,9 @@
 package com.sk.domain.board.api;
 
 import com.sk.domain.board.api.dto.request.BoardCreateRequest;
+import com.sk.domain.board.api.dto.request.BoardUpdateRequest;
 import com.sk.domain.board.api.dto.response.BoardDetailResponse;
 import com.sk.domain.board.api.dto.response.BoardListResponse;
-import com.sk.domain.board.api.dto.request.BoardUpdateRequest;
 import com.sk.domain.board.application.BoardService;
 import com.sk.global.dto.ApiSuccessResponse;
 import com.sk.global.security.CustomUserDetails;
@@ -18,6 +18,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -96,7 +98,7 @@ public class BoardController {
     // 게시글 목록 조회
     @GetMapping
     public ResponseEntity<ApiSuccessResponse<Page<BoardListResponse>>> getBoards(
-            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Optional<String> keyword,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             HttpServletRequest servletRequest
     ) {

--- a/src/main/java/com/sk/domain/board/application/BoardService.java
+++ b/src/main/java/com/sk/domain/board/application/BoardService.java
@@ -47,16 +47,21 @@ public class BoardService {
                 member,
                 boardCreateRequest.title(),
                 boardCreateRequest.content(),
-                boardCreateRequest.attachments() != null && !boardCreateRequest.attachments().isEmpty());
+                hasAttachments(boardCreateRequest));
         boardRepository.save(board);
 
-        // 첨부파일 처리 및 저장
-        if (boardCreateRequest.attachments() != null && !boardCreateRequest.attachments().isEmpty()) {
-            List<Attachment> attachments = boardCreateRequest.attachments().stream()
+        // 첨부파일 저장
+        if (hasAttachments(boardCreateRequest)) {
+            List<Attachment> attachments = boardCreateRequest.attachments()
+                    .stream()
                     .map(file -> createAttachment(board, file))
                     .toList();
             attachmentRepository.saveAll(attachments);
         }
+    }
+
+    private static boolean hasAttachments(BoardCreateRequest boardCreateRequest) {
+        return boardCreateRequest.attachments() != null && !boardCreateRequest.attachments().isEmpty();
     }
 
     // 게시글 수정

--- a/src/main/java/com/sk/domain/board/application/BoardService.java
+++ b/src/main/java/com/sk/domain/board/application/BoardService.java
@@ -1,7 +1,6 @@
 package com.sk.domain.board.application;
 
 import com.sk.domain.auth.domain.Member;
-import com.sk.domain.auth.exception.AccessDeniedException;
 import com.sk.domain.auth.exception.UserNotFoundException;
 import com.sk.domain.auth.repository.MemberRepository;
 import com.sk.domain.board.api.dto.request.BoardCreateRequest;
@@ -68,16 +67,11 @@ public class BoardService {
     @Transactional
     public void updateBoard(Long memberId, Long boardId, BoardUpdateRequest boardUpdateRequest) {
 
-        // 게시글 조회
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);
 
-        // 작성자 확인
-        if (!board.getMember().getId().equals(memberId)) {
-            throw new AccessDeniedException();
-        }
+        board.validateAuthor(memberId);
 
-        // 게시글 수정
         board.update(
                 boardUpdateRequest.title(),
                 boardUpdateRequest.content(),
@@ -118,9 +112,7 @@ public class BoardService {
         Board board = boardRepository.findByIdAndIsDeletedFalse(boardId)
                 .orElseThrow(BoardNotFoundException::new);
 
-        if (!board.getMember().getId().equals(memberId)) {
-            throw new AccessDeniedException();
-        }
+        board.validateAuthor(memberId);
 
         board.deleteAttachments();
         board.delete();

--- a/src/main/java/com/sk/domain/board/domain/Board.java
+++ b/src/main/java/com/sk/domain/board/domain/Board.java
@@ -1,6 +1,7 @@
 package com.sk.domain.board.domain;
 
 import com.sk.domain.auth.domain.Member;
+import com.sk.domain.auth.exception.AccessDeniedException;
 import com.sk.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -71,4 +72,11 @@ public class Board extends BaseEntity {
         this.attachments.forEach(Attachment::delete);
     }
 
+    // 작성자 확인
+    public void validateAuthor(Long memberId) {
+        if (!this.member.getId().equals(memberId)) {
+            throw new AccessDeniedException();
+        }
+    }
+    
 }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- 게시글에 관련된 로직을 메서드로 분리

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?
- 게시글 작성 시 첨부파일 유무 확인 로직 분리
  - hasAttachments 메서드로 첨부파일 확인 로직 추출
- Board 엔티티에 작성자 확인 책임 위임
  - 작성자 확인 로직을 Board 엔티티의 validateAuthor 메서드로 이동
  - 수정 및 삭제 시 중복된 작성자 확인 로직 제거
- 게시글 목록 조회 로직 개선
  - null 초기화 후 분기 처리 로직을 제거하고 Optional<String>을 사용하여 검색 키워드 처리 개선

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
- 브라우저 및 DB에서 정상 동작 확인

---
